### PR TITLE
Change licence to MIT and use your email

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-   DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                   Version 2, December 2004
+The MIT License (MIT)
 
-Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+Copyright (c) 2014 NachoSoto <hello@nachosoto.com>
 
-Everyone is permitted to copy and distribute verbatim or modified
-copies of this license document, and changing it is allowed as long
-as the name is changed.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
- 0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Updates the licence to use a proper licence without swears so we can use it in a public-facing app.

Looks like you copied and pasted the example licence off the DWTFYW licence website. I've updated the licence with your name and email.

This is a really great project and totally fills a hole left in XCode's current feature set but because we use Cocoapods to auto-generate an acknowledgements file, we end up with swears in a publicly facing page. I want to give credit for your work (obviously)! Using the MIT licence doesn't change anything, it's still totally permissive and means that you're not liable for anything. 

Also, I imagine apple doesn't look too fondly on 4+ age rated apps with swear words. Admittedly, it's not easy to find, but Apple are sticklers for detail.

Cheers
